### PR TITLE
Refactor names

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,9 @@ scikit-learn = "^1.5.0"
 pytest = "^8.2.2"
 tox = "^3.20.1"
 
+[tool.poetry.group.testbed.dependencies]
+scikit-optimize = "^0.10.2"
+
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"

--- a/src/treeffuser/_base_tabular_diffusion.py
+++ b/src/treeffuser/_base_tabular_diffusion.py
@@ -236,7 +236,8 @@ class BaseTabularDiffusion(BaseEstimator, abc.ABC):
 
         if n_samples > max_samples:
             warnings.warn(
-                f"Predict method did not converge on {max_samples} samples. Consider increasing `max_samples` for more accurate estimates.",
+                f"Predict method did not converge on {max_samples} samples. Consider increasing "
+                f"`max_samples` for more accurate estimates.",
                 ConvergenceWarning,
                 stacklevel=2,
             )
@@ -322,7 +323,7 @@ class BaseTabularDiffusion(BaseEstimator, abc.ABC):
         X: Float[ndarray, "batch x_dim"],
         y: Float[ndarray, "batch y_dim"],
         n_samples: int = 10,
-        bandwidth: float = 1.0,
+        bandwidth: float | Literal["scott", "silverman"] = 1.0,
         verbose: bool = False,
     ) -> float:
         y_samples = self.sample(X=X, n_samples=n_samples, verbose=verbose)

--- a/src/treeffuser/_base_tabular_diffusion.py
+++ b/src/treeffuser/_base_tabular_diffusion.py
@@ -108,7 +108,7 @@ class BaseTabularDiffusion(BaseEstimator, abc.ABC):
         n_parallel: int = 10,
         n_steps: int = 100,
         seed=None,
-        verbose: int = 0,
+        verbose: bool = False,
     ) -> Float[ndarray, "n_samples batch y_dim"]:
         """
         Sample from the diffusion model.
@@ -125,9 +125,8 @@ class BaseTabularDiffusion(BaseEstimator, abc.ABC):
             Number of steps to take by the SDE solver. Default is 100.
         seed : int, optional
             Seed for the random number generator of the sampling. Default is None.
-        verbose : int, optional
-            Verbosity level. 0 is ... TODO detail
-            Default is 0.
+        verbose : bool, optional
+            Show a progress bar indicating the number of samples drawn. Default is False.
         """
         if not self._is_fitted:
             raise ValueError("The model has not been fitted yet.")
@@ -140,7 +139,7 @@ class BaseTabularDiffusion(BaseEstimator, abc.ABC):
         y_samples = []
         x_batched = None
 
-        pbar = tqdm(total=n_samples, disable=verbose < 1)
+        pbar = tqdm(total=n_samples, disable=~verbose)
         while n_samples_sampled < n_samples:
             batch_size_samples = min(n_parallel, n_samples - n_samples_sampled)
             y_batch = self.sde.sample_from_theoretical_prior(

--- a/src/treeffuser/_base_tabular_diffusion.py
+++ b/src/treeffuser/_base_tabular_diffusion.py
@@ -112,6 +112,22 @@ class BaseTabularDiffusion(BaseEstimator, abc.ABC):
     ) -> Float[ndarray, "n_samples batch y_dim"]:
         """
         Sample from the diffusion model.
+
+        Parameters
+        ----------
+        X : np.ndarray
+            Input data with shape (batch, x_dim).
+        n_samples : int
+            Number of samples to draw for each input.
+        n_parallel : int, optional
+            Number of parallel samples to draw. Default is 10.
+        n_steps : int, optional
+            Number of steps to take by the SDE solver. Default is 100.
+        seed : int, optional
+            Seed for the random number generator of the sampling. Default is None.
+        verbose : int, optional
+            Verbosity level. 0 is ... TODO detail
+            Default is 0.
         """
         if not self._is_fitted:
             raise ValueError("The model has not been fitted yet.")
@@ -277,6 +293,8 @@ class BaseTabularDiffusion(BaseEstimator, abc.ABC):
         bandwidth : Union[float, Literal["scott", "silverman"]], optional
             The bandwidth of the kernel. If bandwidth is a float, it defines the bandwidth of the kernel.
             If bandwidth is a string, one of the  "scott" and "silverman" estimation methods. Default is 1.0.
+        verbose : bool, optional
+            If True, displays a progress bar for the sampling. Default is False.
 
         Returns
         -------

--- a/src/treeffuser/_score_models.py
+++ b/src/treeffuser/_score_models.py
@@ -117,9 +117,7 @@ def _make_training_data(
 
         val_mean, val_std = sde.get_mean_std_pt_given_y0(y_test, t_val)
         perturbed_y_val = val_mean + val_std * z_val
-        predictors_val = np.concatenate(
-            [X_test, perturbed_y_val, t_val.reshape(-1, 1)], axis=1
-        )
+        predictors_val = np.concatenate([X_test, perturbed_y_val, t_val.reshape(-1, 1)], axis=1)
         predicted_val = -1.0 * z_val
 
     # cat_idx is not changed
@@ -163,27 +161,27 @@ class LightGBMScoreModel(ScoreModel):
         How many times to repeat the training dataset when fitting the score. That is, how many
         noisy versions of a point to generate for training.
     eval_percent : float
-        Percentage of the training data to use for validation for optional early stopping. If `None`,
-        no validation set is used. TODO: what happens if eval_percent is not None but early_stopping_rounds is None?
+        Percentage of the training data to use for validation for optional early stopping. It is
+        ignored if `early_stopping_rounds` is not set in the `lgbm_args`.
     n_jobs : int
         LightGBM: Number of parallel threads. If set to -1, the number is set to the number of available cores.
     seed : int
         Random seed for generating the training data and fitting the model.
     verbose : int
         Verbosity of the score model.
+    **lgbm_args
+        Additional arguments to pass to the LightGBM model. See the LightGBM documentation for more
+        information. E.g. `early_stopping_rounds`, `n_estimators`, `learning_rate`, `max_depth`,
     """
 
     def __init__(
         self,
         n_repeats: Optional[int] = 10,
-        eval_percent: Optional[float] = None,
+        eval_percent: float = 0.1,
         n_jobs: Optional[int] = -1,
         seed: Optional[int] = None,
         **lgbm_args,
     ) -> None:
-        if "early_stopping_rounds" in lgbm_args:
-            eval_percent = eval_percent if eval_percent is not None else 0.1
-
         self.n_repeats = n_repeats
         self.eval_percent = eval_percent
         self.n_jobs = n_jobs

--- a/src/treeffuser/_score_models.py
+++ b/src/treeffuser/_score_models.py
@@ -25,52 +25,38 @@ def _fit_one_lgbm_model(
     y: Float[np.ndarray, "batch y_dim"],
     X_val: Float[np.ndarray, "batch x_dim"],
     y_val: Float[np.ndarray, "batch y_dim"],
-    n_estimators: int,
-    num_leaves: int,
-    max_depth: int,
-    learning_rate: float,
-    max_bin: int,
-    subsample_for_bin: int,
-    min_child_samples: int,
-    subsample: float,
-    subsample_freq: int,
-    categorical_features: List[int],
     seed: int,
     verbose: int,
-    early_stopping_rounds: int,
+    cat_idx: Optional[List[int]] = None,
     n_jobs: int = -1,
-) -> lgb.Booster:
+    early_stopping_rounds: Optional[int] = None,
+    **lgbm_args,
+) -> lgb.LGBMRegressor:
     """
     Simple wrapper for fitting a lightgbm model. See
     the lightgbm score function documentation for more details.
     """
     callbacks = None
     if early_stopping_rounds is not None:
-        callbacks = [lgb.early_stopping(early_stopping_rounds, verbose=verbose)]
-
-    categorical_features_idx = (
-        [1 + i for i in categorical_features] if categorical_features is not None else None
-    )  # X_train=[y_perturbed, X, t]
+        callbacks = [lgb.early_stopping(early_stopping_rounds, verbose=verbose > 0)]
 
     model = lgb.LGBMRegressor(
-        n_estimators=n_estimators,
-        num_leaves=num_leaves,
-        max_depth=max_depth,
-        learning_rate=learning_rate,
-        max_bin=max_bin,
-        subsample_for_bin=subsample_for_bin,
-        min_child_samples=min_child_samples,
-        subsample=subsample,
-        subsample_freq=subsample_freq,
-        categorical_features=categorical_features_idx,
         random_state=seed,
         verbose=verbose,
         n_jobs=n_jobs,
         linear_tree=False,
+        **lgbm_args,
     )
     eval_set = None if X_val is None else (X_val, y_val)
-    model.fit(X=X, y=y, eval_set=eval_set, callbacks=callbacks)
-
+    if cat_idx is None:
+        cat_idx = "auto"
+    model.fit(
+        X=X,
+        y=y,
+        eval_set=eval_set,
+        callbacks=callbacks,
+        categorical_feature=cat_idx,
+    )
     return model
 
 
@@ -80,11 +66,12 @@ def _make_training_data(
     sde: DiffusionSDE,
     n_repeats: int,
     eval_percent: Optional[float],
+    cat_idx: Optional[List[int]] = None,
     seed: Optional[int] = None,
 ):
     """
     Creates the training data for the score model. This functions assumes that
-    1.  Score is parametrized as score(y, x, t) = GBT(y, x, t) / std(t)
+    1.  Score is parametrized as score(x, y, t) = GBT(x, y, t) / std(t)
     2.  The loss that we want to use is
         || std(t) * score(y_perturbed, x, t) - (mean(y, t) - y_perturbed)/std(t) ||^2
         Which corresponds to the standard denoising objective with weights std(t)**2
@@ -93,8 +80,8 @@ def _make_training_data(
         where z is the noise added to y_perturbed.
 
     Returns:
-    - predictors_train: X_train=[y_perturbed_train, x_train, t_train] for lgbm
-    - predictors_val: X_val=[y_perturbed_val, x_val, t_val] for lgbm
+    - predictors_train: X_train=[x_train, y_perturbed_train, t_train] for lgbm
+    - predictors_val: X_val=[x_val, y_perturbed_val, t_val] for lgbm
     - predicted_train: y_train=[-z_train] for lgbm
     - predicted_val: y_val=[-z_val] for lgbm
     """
@@ -121,7 +108,7 @@ def _make_training_data(
     train_mean, train_std = sde.get_mean_std_pt_given_y0(y_train, t_train)
     perturbed_y_train = train_mean + train_std * z_train
 
-    predictors_train = np.concatenate([perturbed_y_train, X_train, t_train], axis=1)
+    predictors_train = np.concatenate([X_train, perturbed_y_train, t_train], axis=1)
     predicted_train = -1.0 * z_train
 
     # VALIDATION DATA
@@ -132,11 +119,12 @@ def _make_training_data(
         val_mean, val_std = sde.get_mean_std_pt_given_y0(y_test, t_val)
         perturbed_y_val = val_mean + val_std * z_val
         predictors_val = np.concatenate(
-            [perturbed_y_val, X_test, t_val.reshape(-1, 1)], axis=1
+            [X_test, perturbed_y_val, t_val.reshape(-1, 1)], axis=1
         )
         predicted_val = -1.0 * z_val
 
-    return predictors_train, predictors_val, predicted_train, predicted_val
+    # cat_idx is not changed
+    return predictors_train, predictors_val, predicted_train, predicted_val, cat_idx
 
 
 ###################################################
@@ -144,7 +132,7 @@ def _make_training_data(
 ###################################################
 
 
-class Score(abc.ABC):
+class ScoreModel(abc.ABC):
     @abc.abstractmethod
     def score(
         self,
@@ -156,99 +144,55 @@ class Score(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def fit(self, X: Float[np.ndarray, "batch x_dim"], y: Float[np.ndarray, "batch y_dim"]):
+    def fit(
+        self,
+        X: Float[np.ndarray, "batch x_dim"],
+        y: Float[np.ndarray, "batch y_dim"],
+        sde: DiffusionSDE,
+        cat_idx: Optional[List[int]] = None,
+    ):
         pass
 
 
-# lightgbm score
-class LightGBMScore(Score):
+class LightGBMScoreModel(ScoreModel):
+    """
+    A score model that uses a LightGBM model (trees) to approximate the score of a given SDE.
+
+    Parameters
+    ----------
+    n_repeats : int
+        How many times to repeat the training dataset when fitting the score. That is, how many
+        noisy versions of a point to generate for training.
+    eval_percent : float
+        Percentage of the training data to use for validation for optional early stopping. If `None`,
+        no validation set is used. TODO: what happens if eval_percent is not None but early_stopping_rounds is None?
+    n_jobs : int
+        LightGBM: Number of parallel threads. If set to -1, the number is set to the number of available cores.
+    seed : int
+        Random seed for generating the training data and fitting the model.
+    verbose : int
+        Verbosity of the score model.
+    """
+
     def __init__(
         self,
-        sde: DiffusionSDE,
-        n_repeats: Optional[int] = 1,
-        n_estimators: Optional[int] = 100,
+        n_repeats: Optional[int] = 10,
         eval_percent: Optional[float] = None,
-        early_stopping_rounds: Optional[int] = None,
-        num_leaves: Optional[int] = 31,
-        max_depth: Optional[int] = -1,
-        learning_rate: Optional[float] = 0.1,
-        max_bin: Optional[int] = 255,
-        subsample_for_bin: Optional[int] = 200000,
-        min_child_samples: Optional[int] = 20,
-        subsample: Optional[float] = 1.0,
-        subsample_freq: Optional[int] = 0,
-        categorical_features: Optional[list[int]] = None,
-        verbose: Optional[int] = 0,
-        seed: Optional[int] = None,
         n_jobs: Optional[int] = -1,
+        seed: Optional[int] = None,
+        **lgbm_args,
     ) -> None:
-        """
-        Args:
-        This model doesn't do any model checking or validation. It's assumed that
-        that the main user is the `Treeffuser` class and that the user has already
-        checked that the inputs are valid.
-
-            Diffusion model args
-            -------------------------------
-            sde (SDE): A member from the SDE class specifying the sde that is implied
-                by the score model.
-            n_repeats (int): How many times to repeat the training dataset. i.e how
-                many noisy versions of a point to generate for training.
-
-            LightGBM args
-            -------------------------------
-            eval_percent (float): Percentage of the training data to use for validation.
-                If `None`, no validation set is used.
-            early_stopping_rounds (int): If `None`, no early stopping is performed. Otherwise,
-                the model will stop training if no improvement is observed in the validation
-                set for `early_stopping_rounds` consecutive iterations.
-            n_estimators (int): Number of boosting iterations.
-            num_leaves (int): Maximum tree leaves for base learners.
-            max_depth (int): Maximum tree depth for base learners, <=0 means no limit.
-            learning_rate (float): Boosting learning rate.
-            max_bin (int): Max number of bins that feature values will be bucketed in. This
-                is used for lightgbm's histogram binning algorithm.
-            subsample_for_bin (int): Number of samples for constructing bins (can ignore).
-            min_child_samples (int): Minimum number of data needed in a child (leaf). If
-                less than this number, will not create the child.
-            subsample (float): Subsample ratio of the training instance.
-            subsample_freq (int): Frequence of subsample, <=0 means no enable.
-                How often to subsample the training data.
-            seed (int): Random seed.
-            early_stopping_rounds (int): If `None`, no early stopping is performed. Otherwise,
-                the model will stop training if no improvement is observed in the validation
-            n_jobs (int): Number of parallel threads. If set to -1, the number is set to the
-                number of available cores.
-        """
-        if early_stopping_rounds is not None:
+        if "early_stopping_rounds" in lgbm_args:
             eval_percent = eval_percent if eval_percent is not None else 0.1
 
-        # Diffusion model args
-        self._sde = sde
-        self._n_repeats = n_repeats
-        self._eval_percent = eval_percent
+        self.n_repeats = n_repeats
+        self.eval_percent = eval_percent
+        self.n_jobs = n_jobs
+        self.seed = seed
 
-        # LightGBM args
-        self._lgbm_args = {
-            "early_stopping_rounds": early_stopping_rounds,
-            "n_estimators": n_estimators,
-            "num_leaves": num_leaves,
-            "max_depth": max_depth,
-            "learning_rate": learning_rate,
-            "max_bin": max_bin,
-            "subsample_for_bin": subsample_for_bin,
-            "min_child_samples": min_child_samples,
-            "subsample": subsample,
-            "subsample_freq": subsample_freq,
-            "categorical_features": categorical_features,
-            "seed": seed,
-            "verbose": verbose,
-            "n_jobs": n_jobs,
-        }
-
-        # Other stuff part of internal state
-        self.models = None  # Convention inputs are (y, x, t)
-        self.is_fitted = False
+        self._lgbm_args = lgbm_args
+        self.sde = None
+        self.models = None  # Convention inputs are (x, y, t)
 
     def score(
         self,
@@ -256,12 +200,15 @@ class LightGBMScore(Score):
         X: Float[np.ndarray, "batch x_dim"],
         t: Int[np.ndarray, "batch 1"],
     ) -> Float[np.ndarray, "batch y_dim"]:
+        if self.sde is None:
+            raise ValueError("The model has not been fitted yet.")
+
         scores = []
-        predictors = np.concatenate([y, X, t], axis=1)
-        _, std = self._sde.get_mean_std_pt_given_y0(y, t)
+        predictors = np.concatenate([X, y, t], axis=1)
+        _, std = self.sde.get_mean_std_pt_given_y0(y, t)
         for i in range(y.shape[-1]):
-            # The score is parametrized: score(y, x, t) = GBT(y, x, t) / std(t)
-            score_p = self.models[i].predict(predictors, num_threads=self._lgbm_args["n_jobs"])
+            # The score is parametrized: score(x, y, t) = GBT(x, y, t) / std(t)
+            score_p = self.models[i].predict(predictors, num_threads=self.n_jobs)
             score = score_p / std[:, i]
             scores.append(score)
         return np.array(scores).T
@@ -270,6 +217,8 @@ class LightGBMScore(Score):
         self,
         X: Float[np.ndarray, "batch x_dim"],
         y: Float[np.ndarray, "batch y_dim"],
+        sde: DiffusionSDE,
+        cat_idx: Optional[List[int]] = None,
     ):
         """
         Fit the score model to the data.
@@ -284,14 +233,16 @@ class LightGBMScore(Score):
                 otherwise use the weighting recommended in song's SDEs paper.
         """
         y_dim = y.shape[1]
+        self.sde = sde
 
-        lgb_X_train, lgb_X_val, lgb_y_train, lgb_y_val = _make_training_data(
+        lgb_X_train, lgb_X_val, lgb_y_train, lgb_y_val, cat_idx = _make_training_data(
             X=X,
             y=y,
-            sde=self._sde,
-            n_repeats=self._n_repeats,
-            eval_percent=self._eval_percent,
-            seed=self._lgbm_args["seed"],
+            sde=self.sde,
+            n_repeats=self.n_repeats,
+            eval_percent=self.eval_percent,
+            cat_idx=cat_idx,
+            seed=self.seed,
         )
 
         models = []
@@ -302,6 +253,9 @@ class LightGBMScore(Score):
                 y=lgb_y_train[:, i],
                 X_val=lgb_X_val,
                 y_val=lgb_y_val_i,
+                cat_idx=cat_idx,
+                seed=self.seed,
+                n_jobs=self.n_jobs,
                 **self._lgbm_args,
             )
             models.append(score_model_i)

--- a/src/treeffuser/_score_models.py
+++ b/src/treeffuser/_score_models.py
@@ -117,7 +117,9 @@ def _make_training_data(
 
         val_mean, val_std = sde.get_mean_std_pt_given_y0(y_test, t_val)
         perturbed_y_val = val_mean + val_std * z_val
-        predictors_val = np.concatenate([X_test, perturbed_y_val, t_val.reshape(-1, 1)], axis=1)
+        predictors_val = np.concatenate(
+            [X_test, perturbed_y_val, t_val.reshape(-1, 1)], axis=1
+        )
         predicted_val = -1.0 * z_val
 
     # cat_idx is not changed

--- a/src/treeffuser/_score_models.py
+++ b/src/treeffuser/_score_models.py
@@ -15,7 +15,7 @@ from sklearn.model_selection import train_test_split
 from treeffuser.sde import DiffusionSDE
 
 ###################################################
-# Helper functions # TODO move at the bottom
+# Helper functions
 ###################################################
 
 

--- a/src/treeffuser/_score_models.py
+++ b/src/treeffuser/_score_models.py
@@ -1,6 +1,5 @@
 """
-This file should contain a general abstraction of the score models and
-should function as a wrapper for different models we might want to use.
+Contains different score models to be used to approximate the score of a given SDE.
 """
 
 import abc
@@ -16,7 +15,7 @@ from sklearn.model_selection import train_test_split
 from treeffuser.sde import DiffusionSDE
 
 ###################################################
-# Helper functions
+# Helper functions # TODO move at the bottom
 ###################################################
 
 
@@ -221,16 +220,19 @@ class LightGBMScoreModel(ScoreModel):
         cat_idx: Optional[List[int]] = None,
     ):
         """
-        Fit the score model to the data.
+        Fit the score model to the data and the given SDE.
 
-        Args:
-            X: input data
-            y: target data
-            n_repeats: How many times to repeat the training dataset.
-            likelihood_reweighting: Whether to reweight the likelihoods.
-            likelihood_weighting: If `True`, weight the mixture of score
-                matching losses according to https://arxiv.org/abs/2101.09258;
-                otherwise use the weighting recommended in song's SDEs paper.
+        Parameters
+        ----------
+        X : Float[np.ndarray, "batch x_dim"]
+            The input data.
+        y : Float[np.ndarray, "batch y_dim"]
+            The true output values.
+        sde : DiffusionSDE
+            The SDE that the model is supposed to approximate the score of.
+        cat_idx : Optional[List[int]]
+            List of indices of categorical features in the input data. If `None`, all features are
+            assumed to be continuous.
         """
         y_dim = y.shape[1]
         self.sde = sde

--- a/src/treeffuser/sde/__init__.py
+++ b/src/treeffuser/sde/__init__.py
@@ -1,21 +1,21 @@
-import treeffuser.sde.sdes
+import treeffuser.sde.diffusion_sdes  # noqa: F401
 import treeffuser.sde.solvers  # noqa: F401
 from treeffuser.sde.base_sde import BaseSDE
 from treeffuser.sde.base_sde import CustomSDE
 from treeffuser.sde.base_sde import ReverseSDE
-from treeffuser.sde.base_sde import get_sde
 from treeffuser.sde.base_solver import get_solver
 from treeffuser.sde.base_solver import sdeint
-from treeffuser.sde.sdes import VESDE
-from treeffuser.sde.sdes import VPSDE
-from treeffuser.sde.sdes import DiffusionSDE
-from treeffuser.sde.sdes import SubVPSDE
+from treeffuser.sde.diffusion_sdes import VESDE
+from treeffuser.sde.diffusion_sdes import VPSDE
+from treeffuser.sde.diffusion_sdes import DiffusionSDE
+from treeffuser.sde.diffusion_sdes import SubVPSDE
+from treeffuser.sde.diffusion_sdes import get_diffusion_sde
 
 __all__ = [
     "BaseSDE",
     "ReverseSDE",
     "CustomSDE",
-    "get_sde",
+    "get_diffusion_sde",
     "sdeint",
     "get_solver",
     "DiffusionSDE",

--- a/src/treeffuser/sde/__init__.py
+++ b/src/treeffuser/sde/__init__.py
@@ -1,4 +1,4 @@
-import treeffuser.sde.diffusion_sdes  # noqa: F401
+import treeffuser.sde.diffusion_sdes
 import treeffuser.sde.solvers  # noqa: F401
 from treeffuser.sde.base_sde import BaseSDE
 from treeffuser.sde.base_sde import CustomSDE

--- a/src/treeffuser/sde/base_sde.py
+++ b/src/treeffuser/sde/base_sde.py
@@ -4,8 +4,6 @@ from typing import Callable
 from jaxtyping import Float
 from numpy import ndarray
 
-_AVAILABLE_SDES = {}
-
 
 class BaseSDE(abc.ABC):
     """
@@ -119,54 +117,3 @@ class CustomSDE(BaseSDE):
 
     def __repr__(self):
         return f"CustomSDE(drift_fn={self.drift_fn}, diffusion_fn={self.diffusion_fn})"
-
-
-def _register_sde(name: str):
-    """
-    A decorator for registering available SDEs and making them accessible by name,
-    with the `get_sde` function.
-
-    Args:
-        name (str): Name of the SDE.
-
-    Examples:
-        >>> @_register_sde(name="my_sde")
-        ... class MySDE(BaseSDE):
-        ...     def drift_and_diffusion(self, y, t):
-        ...         ...
-        >>> sde_cls = get_sde("my_sde")
-        >>> sde_instance = sde_cls()
-
-    See Also:
-        get_sde: Function to get an SDE by name.
-    """
-
-    def _register(cls):
-        if name in _AVAILABLE_SDES:
-            raise ValueError(f"Already registered SDE with name: {name}")
-        _AVAILABLE_SDES[name] = cls
-        return cls
-
-    return _register
-
-
-def get_sde(name: str):
-    """
-    Function to retrieve a registered SDE by its name.
-
-    Args:
-        name (str): The name of the SDE.
-
-    Raises:
-        ValueError: If the SDE with the given name is not registered.
-
-    Returns:
-        The class of the registered SDE.
-
-    Examples:
-        >>> sde_class = get_sde("my_sde")
-        >>> sde_instance = sde_class()
-    """
-    if name not in _AVAILABLE_SDES:
-        raise ValueError(f"Unknown SDE {name}. Available SDEs: {list(_AVAILABLE_SDES.keys())}")
-    return _AVAILABLE_SDES[name]

--- a/src/treeffuser/sde/diffusion_sdes.py
+++ b/src/treeffuser/sde/diffusion_sdes.py
@@ -1,6 +1,7 @@
 import abc
 from typing import Dict
 from typing import Optional
+from typing import Type
 from typing import Union
 
 import numpy as np
@@ -8,9 +9,13 @@ from jaxtyping import Float
 from numpy import ndarray
 
 from .base_sde import BaseSDE
-from .base_sde import _register_sde
+from .initialize import initialize_subvpsde
+from .initialize import initialize_vesde
+from .initialize import initialize_vpsde
 from .parameter_schedule import ExponentialSchedule
 from .parameter_schedule import LinearSchedule
+
+_AVAILABLE_DIFFUSION_SDES = {}
 
 
 class DiffusionSDE(BaseSDE):
@@ -20,6 +25,18 @@ class DiffusionSDE(BaseSDE):
     diffusion coefficient independent of `Y`, and the drift is an affine function of Y.
     As a result, the conditional distribution p_t(y | y0) is Gaussian.
     """
+
+    def initialize_hyperparams_from_data(self, y0: Float[ndarray, "batch y_dim"]) -> None:
+        """
+        Initialize the hyperparameters of the SDE from the data `y0`.
+
+        This method can be implemented by subclasses to initialize the hyperparameters.
+
+        Parameters
+        ----------
+        y0 : ndarray of shape (*batch, y_dim)
+            Data y0.
+        """
 
     @property
     def T(self) -> float:
@@ -113,7 +130,67 @@ class DiffusionSDE(BaseSDE):
         return kernel_density_fn
 
 
-@_register_sde(name="vesde")
+def _register_diffusion_sde(name: str):
+    """
+    A decorator for registering available diffusion SDEs and making them accessible by name,
+    with the `get_diffusion_sde` function.
+
+    Args:
+        name (str): Name of the SDE.
+
+    Examples:
+        >>> @_register_diffusion_sde(name="my_sde")
+        ... class MySDE(BaseSDE):
+        ...     def drift_and_diffusion(self, y, t):
+        ...         ...
+        >>> sde_cls = get_diffusion_sde("my_sde")
+        >>> sde_instance = sde_cls()
+
+    See Also:
+        get_diffusion_sde: Function to get an SDE by name.
+    """
+
+    def _register(cls):
+        if name in _AVAILABLE_DIFFUSION_SDES:
+            raise ValueError(f"Already registered DiffusionSDE with name: {name}")
+        _AVAILABLE_DIFFUSION_SDES[name] = cls
+        return cls
+
+    return _register
+
+
+def get_diffusion_sde(name: Optional[str] = None) -> Type[DiffusionSDE] | dict:
+    """
+    Function to retrieve a registered diffusion SDE by its name.
+
+    Parameters:
+    -----------
+    name: str
+        The name of the SDE to retrieve. If None, returns a dictionary of all available SDEs.
+
+    Returns:
+    --------
+    BaseSDE or dict: The SDE class corresponding to the given name, or a dictionary of all available SDEs.
+
+    Raises:
+    -------
+    ValueError: If the given name is not registered.
+
+    Examples:
+    ---------
+        >>> sde_class = get_diffusion_sde("my_sde")
+        >>> sde_instance = sde_class()
+    """
+    if name is None:
+        return _AVAILABLE_DIFFUSION_SDES
+    if name not in _AVAILABLE_DIFFUSION_SDES:
+        raise ValueError(
+            f"Unknown SDE {name}. Available SDEs: {list(_AVAILABLE_DIFFUSION_SDES.keys())}"
+        )
+    return _AVAILABLE_DIFFUSION_SDES[name]
+
+
+@_register_diffusion_sde(name="vesde")
 class VESDE(DiffusionSDE):
     """
     Variance-exploding SDE (VESDE):
@@ -133,6 +210,24 @@ class VESDE(DiffusionSDE):
     """
 
     def __init__(self, hyperparam_min=0.01, hyperparam_max=20):
+        self.hyperparam_min = None
+        self.hyperparam_max = None
+        self.hyperparam_schedule = None
+        self.set_hyperparams(hyperparam_min, hyperparam_max)
+
+    def initialize_hyperparams_from_data(self, y0: Float[ndarray, "batch y_dim"]) -> None:
+        """
+        Initialize the hyperparameters of the SDE from the data `y0`.
+
+        Parameters
+        ----------
+        y0 : ndarray of shape (*batch, y_dim)
+            Data y0.
+        """
+        hyperparam_min, hyperparam_max = initialize_vesde(y0)
+        self.set_hyperparams(hyperparam_min, hyperparam_max)
+
+    def set_hyperparams(self, hyperparam_min, hyperparam_max):
         self.hyperparam_min = hyperparam_min
         self.hyperparam_max = hyperparam_max
         self.hyperparam_schedule = ExponentialSchedule(hyperparam_min, hyperparam_max)
@@ -142,10 +237,10 @@ class VESDE(DiffusionSDE):
 
     def drift_and_diffusion(
         self, y: Float[ndarray, "batch y_dim"], t: Float[ndarray, "batch 1"]
-    ) -> tuple[Float[ndarray, "batch y_dim"], Float[ndarray, "batch y_dim"]]:
+    ) -> tuple[Float[ndarray, "batch y_dim"] | float, Float[ndarray, "batch y_dim"] | float]:
         hyperparam = self.hyperparam_schedule(t)
         hyperparam_prime = self.hyperparam_schedule.get_derivative(t)
-        drift = 0
+        drift = 0.0
         diffusion = np.sqrt(2 * hyperparam * hyperparam_prime)
         return drift, diffusion
 
@@ -178,7 +273,7 @@ class VESDE(DiffusionSDE):
         return f"VESDE(hyperparam_min={self.hyperparam_min}, hyperparam_max={self.hyperparam_max})"
 
 
-@_register_sde(name="vpsde")
+@_register_diffusion_sde(name="vpsde")
 class VPSDE(DiffusionSDE):
     """
     Variance-preserving SDE (VPSDE):
@@ -197,9 +292,27 @@ class VPSDE(DiffusionSDE):
     """
 
     def __init__(self, hyperparam_min=0.01, hyperparam_max=20):
+        self.hyperparam_min = None
+        self.hyperparam_max = None
+        self.hyperparam_schedule = None
+        self.set_hyperparams(hyperparam_min, hyperparam_max)
+
+    def set_hyperparams(self, hyperparam_min, hyperparam_max):
         self.hyperparam_min = hyperparam_min
         self.hyperparam_max = hyperparam_max
         self.hyperparam_schedule = LinearSchedule(hyperparam_min, hyperparam_max)
+
+    def initialize_hyperparams_from_data(self, y0: Float[ndarray, "batch y_dim"]) -> None:
+        """
+        Initialize the hyperparameters of the SDE from the data `y0`.
+
+        Parameters
+        ----------
+        y0 : ndarray of shape (*batch, y_dim)
+            Data y0.
+        """
+        hyperparam_min, hyperparam_max = initialize_vpsde(y0)
+        self.set_hyperparams(hyperparam_min, hyperparam_max)
 
     def get_hyperparams(self):
         return {"hyperparam_min": self.hyperparam_min, "hyperparam_max": self.hyperparam_max}
@@ -241,7 +354,7 @@ class VPSDE(DiffusionSDE):
         return f"VPSDE(hyperparam_min={self.hyperparam_min}, hyperparam_max={self.hyperparam_max})"
 
 
-@_register_sde(name="sub-vpsde")
+@_register_diffusion_sde(name="sub-vpsde")
 class SubVPSDE(DiffusionSDE):
     """
     Sub-Variance-preserving SDE (SubVPSDE):
@@ -260,6 +373,24 @@ class SubVPSDE(DiffusionSDE):
     """
 
     def __init__(self, hyperparam_min=0.01, hyperparam_max=20):
+        self.hyperparam_min = None
+        self.hyperparam_max = None
+        self.hyperparam_schedule = None
+        self.set_hyperparams(hyperparam_min, hyperparam_max)
+
+    def initialize_hyperparams_from_data(self, y0: Float[ndarray, "batch y_dim"]) -> None:
+        """
+        Initialize the hyperparameters of the SDE from the data `y0`.
+
+        Parameters
+        ----------
+        y0 : ndarray of shape (*batch, y_dim)
+            Data y0.
+        """
+        hyperparam_min, hyperparam_max = initialize_subvpsde(y0)
+        self.set_hyperparams(hyperparam_min, hyperparam_max)
+
+    def set_hyperparams(self, hyperparam_min, hyperparam_max):
         self.hyperparam_min = hyperparam_min
         self.hyperparam_max = hyperparam_max
         self.hyperparam_schedule = LinearSchedule(hyperparam_min, hyperparam_max)

--- a/src/treeffuser/sde/diffusion_sdes.py
+++ b/src/treeffuser/sde/diffusion_sdes.py
@@ -210,9 +210,9 @@ class VESDE(DiffusionSDE):
     """
 
     def __init__(self, hyperparam_min=0.01, hyperparam_max=20):
-        self.hyperparam_min = None
-        self.hyperparam_max = None
         self.hyperparam_schedule = None
+        self.hyperparam_min = 0.0
+        self.hyperparam_max = 0.0
         self.set_hyperparams(hyperparam_min, hyperparam_max)
 
     def initialize_hyperparams_from_data(self, y0: Float[ndarray, "batch y_dim"]) -> None:
@@ -292,9 +292,9 @@ class VPSDE(DiffusionSDE):
     """
 
     def __init__(self, hyperparam_min=0.01, hyperparam_max=20):
-        self.hyperparam_min = None
-        self.hyperparam_max = None
         self.hyperparam_schedule = None
+        self.hyperparam_min = 0.0
+        self.hyperparam_max = 0.0
         self.set_hyperparams(hyperparam_min, hyperparam_max)
 
     def set_hyperparams(self, hyperparam_min, hyperparam_max):
@@ -373,9 +373,9 @@ class SubVPSDE(DiffusionSDE):
     """
 
     def __init__(self, hyperparam_min=0.01, hyperparam_max=20):
-        self.hyperparam_min = None
-        self.hyperparam_max = None
         self.hyperparam_schedule = None
+        self.hyperparam_min = 0.0
+        self.hyperparam_max = 0.0
         self.set_hyperparams(hyperparam_min, hyperparam_max)
 
     def initialize_hyperparams_from_data(self, y0: Float[ndarray, "batch y_dim"]) -> None:

--- a/src/treeffuser/sde/initialize.py
+++ b/src/treeffuser/sde/initialize.py
@@ -90,7 +90,9 @@ def _kl_univariate_gaussians(
     `log (scale_2 / scale_1) + (scale_1^2 + (loc_1 - loc_2) ^ 2) / (2 * scale_2^2) - .5`.
     """
     return (
-        np.log(scale_2 / scale_1) + (scale_1**2 + (loc_1 - loc_2) ** 2) / (2 * scale_2**2) - 1 / 2
+        np.log(scale_2 / scale_1)
+        + (scale_1**2 + (loc_1 - loc_2) ** 2) / (2 * scale_2**2)
+        - 1 / 2
     )
 
 

--- a/src/treeffuser/sde/initialize.py
+++ b/src/treeffuser/sde/initialize.py
@@ -1,17 +1,11 @@
 import warnings
 from typing import Callable
-from typing import Optional
 from typing import Tuple
-from typing import Union
 
 import numpy as np
 from jaxtyping import Float
 
-from .base_sde import get_sde
 from .parameter_schedule import LinearSchedule
-from .sdes import VESDE
-from .sdes import VPSDE
-from .sdes import SubVPSDE
 
 
 class ConvergenceWarning(Warning):
@@ -19,58 +13,7 @@ class ConvergenceWarning(Warning):
     pass
 
 
-def initialize_sde(
-    name: str,
-    y0: Float[np.ndarray, "batch y_dim"],
-    T: float = 1,
-    kl_tol: Optional[float] = 10 ** (-5),
-    verbose: bool = False,
-) -> Union[VESDE, VPSDE, SubVPSDE]:
-    """
-    Initializes an SDE model based on the given name and initial data.
-
-    For all SDEs, it sets `hyperparam_min` to 0.01. For VESDE, it sets `hyperparam_max`
-    to the maximum pairwise distance in y0, following [1]. For VPSDE and Sub-VPSDE, it
-    sets `hyperparam_max` to the smallest value that controls the KL divergence between
-    the perturbation kernel at T and the theoretical prior.
-
-    Parameters
-    ----------
-    name : str
-        The SDE model to initialize ('vesde', 'vpsde', 'sub-vpsde').
-    y0 : np.ndarray
-        The data array with the training outcome.
-    T : float, optional
-        End time of the SDE, default is 1.
-    kl_tol : float, optional
-        kl divergence tolerance for initialization, default is 1e-5. This is only used
-        for VPSDE and Sub-VPSDE.
-
-    Returns
-    -------
-    An instance of the specified SDE model.
-
-    References
-    -------
-        [1] Song, Y. and Ermon, S., 2020. Improved techniques for training score-based
-        generative models. NeurIPS (2020).
-    """
-    if name.lower() == "vesde":
-        hyperparam_min, hyperparam_max = _initialize_vesde(y0)
-    elif name.lower() == "vpsde":
-        hyperparam_min, hyperparam_max = _initialize_vpsde(y0, T, kl_tol)
-    elif name.lower() == "sub-vpsde":
-        hyperparam_min, hyperparam_max = _initialize_subvpsde(y0, T, kl_tol)
-    else:
-        raise NotImplementedError
-
-    sde = get_sde(name)(hyperparam_min, hyperparam_max)
-    if verbose:
-        print(sde)
-    return sde
-
-
-def _initialize_vesde(y0: Float[np.ndarray, "batch y_dim"]) -> Tuple[float, float]:
+def initialize_vesde(y0: Float[np.ndarray, "batch y_dim"]) -> Tuple[float, float]:
     hyperparam_min = 0.01
     if y0.shape[1] == 1:
         max_pairwise_difference = y0.max() - y0.min()
@@ -80,7 +23,7 @@ def _initialize_vesde(y0: Float[np.ndarray, "batch y_dim"]) -> Tuple[float, floa
     return hyperparam_min, max_pairwise_difference
 
 
-def _initialize_vpsde(
+def initialize_vpsde(
     y0: Float[np.ndarray, "batch y_dim"], T: float = 1, kl_tol: float = 10 ** (-5)
 ) -> Tuple[float, float]:
     hyperparam_min = 0.01
@@ -110,7 +53,7 @@ def _initialize_vpsde(
     return hyperparam_min, hyperparam_max
 
 
-def _initialize_subvpsde(
+def initialize_subvpsde(
     y0: Float[np.ndarray, "batch y_dim"], T: float = 1, kl_tol: float = 10 ** (-5)
 ) -> Tuple[float, float]:
     hyperparam_min = 0.01
@@ -168,6 +111,9 @@ def _bisect(
     - f is continuous and decreasing in [a, b]
     - |f(a)| > tol and |f(b)| <= tol.
     """
+    if max_iter <= 0:
+        raise ValueError("max_iter must be greater than 0.")
+    x = 0
     for _ in range(max_iter):
         x = (a + b) / 2
         if np.abs(f(x)) > tol:

--- a/src/treeffuser/sde/initialize.py
+++ b/src/treeffuser/sde/initialize.py
@@ -29,8 +29,8 @@ def initialize_vpsde(
     hyperparam_min = 0.01
     y0_max = y0.max()
 
-    def kl_helper(hyperparam_max):
-        schedule = LinearSchedule(hyperparam_min, hyperparam_max)
+    def kl_helper(hyperparam_max_local):
+        schedule = LinearSchedule(hyperparam_min, hyperparam_max_local)
         hyperparam_integral = schedule.get_integral(T)
         kl = _kl_univariate_gaussians(
             y0_max * np.exp(-0.5 * hyperparam_integral),
@@ -59,8 +59,8 @@ def initialize_subvpsde(
     hyperparam_min = 0.01
     y0_max = y0.max()
 
-    def kl_helper(hyperparam_max):
-        schedule = LinearSchedule(hyperparam_min, hyperparam_max)
+    def kl_helper(hyperparam_max_local):
+        schedule = LinearSchedule(hyperparam_min, hyperparam_max_local)
         hyperparam_integral = schedule.get_integral(T)
         kl = _kl_univariate_gaussians(
             y0_max * np.exp(-0.5 * hyperparam_integral), 1 - np.exp(-hyperparam_integral), 0, 1
@@ -90,9 +90,7 @@ def _kl_univariate_gaussians(
     `log (scale_2 / scale_1) + (scale_1^2 + (loc_1 - loc_2) ^ 2) / (2 * scale_2^2) - .5`.
     """
     return (
-        np.log(scale_2 / scale_1)
-        + (scale_1**2 + (loc_1 - loc_2) ** 2) / (2 * scale_2**2)
-        - 1 / 2
+        np.log(scale_2 / scale_1) + (scale_1**2 + (loc_1 - loc_2) ** 2) / (2 * scale_2**2) - 1 / 2
     )
 
 

--- a/src/treeffuser/treeffuser.py
+++ b/src/treeffuser/treeffuser.py
@@ -14,8 +14,8 @@ class Treeffuser(BaseTabularDiffusion):
         self,
         n_repeats: int = 10,
         n_estimators: int = 100,
-        eval_percent: Optional[float] = None,
         early_stopping_rounds: Optional[int] = None,
+        eval_percent: float = 0.1,
         num_leaves: int = 31,
         max_depth: int = -1,
         learning_rate: float = 0.1,
@@ -38,13 +38,13 @@ class Treeffuser(BaseTabularDiffusion):
             noisy versions of a point to generate for training.
         n_estimators : int
             LightGBM: Number of boosting iterations.
-        eval_percent : float
-            LightGBM: Percentage of the training data to use for validation. If `None`, no validation
-            set is used TODO: what happen if early_stopping_rounds is not None but eval_percent is None?
         early_stopping_rounds : int
             LightGBM: If `None`, no early stopping is performed. Otherwise, the model will stop training
             if no improvement is observed in the validation set for `early_stopping_rounds` consecutive
             iterations.
+        eval_percent : float
+            LightGBM: Percentage of the training data to use for validation if `early_stopping_rounds`
+            is not `None`.
         num_leaves : int
             LightGBM: Maximum tree leaves for base learners.
         max_depth : int
@@ -71,9 +71,9 @@ class Treeffuser(BaseTabularDiffusion):
             initialized with a heuristic based on the data (see `treeffuser.sde.initialize.py`).
             Otherwise, sde_hyperparam_min and sde_hyperparam_max are used. (default: False)
         sde_hyperparam_min : float or "default"
-            SDE: TODO
-        sd_hyperparam_max : float or "default"
-            SDE: TODO
+            SDE: The scale of the SDE at t=0 (see `VESDE`, `VPSDE`, `SubVPSDE`).
+        sde_hyperparam_max : float or "default"
+            SDE: The scale of the SDE at t=T (see `VESDE`, `VPSDE`, `SubVPSDE`).
         seed : int
             Random seed for generating the training data and fitting the model.
         verbose : int

--- a/src/treeffuser/treeffuser.py
+++ b/src/treeffuser/treeffuser.py
@@ -33,39 +33,51 @@ class Treeffuser(BaseTabularDiffusion):
         extra_lightgbm_params: Optional[dict] = None,
     ):
         """
-        Diffusion model args
-        -------------------------------
-        sde_name (str): The SDE name.
-        sde_initialize_with_data (bool): Whether to initialize the SDE hyperparameters
-            with data.
-        sde_manual_hyperparams: (dict): A dictionary for explicitly setting the SDE
-            hyperparameters, overriding default or data-based initializations.
-        n_repeats (int): How many times to repeat the training dataset. i.e how
-            many noisy versions of a point to generate for training.
-        LightGBM args
-        -------------------------------
-        eval_percent (float): Percentage of the training data to use for validation.
-            If `None`, no validation set is used.
-        early_stopping_rounds (int): If `None`, no early stopping is performed. Otherwise,
-            the model will stop training if no improvement is observed in the validation
-            set for `early_stopping_rounds` consecutive iterations.
-        n_estimators (int): Number of boosting iterations.
-        num_leaves (int): Maximum tree leaves for base learners.
-        max_depth (int): Maximum tree depth for base learners, <=0 means no limit.
-        learning_rate (float): Boosting learning rate.
-        max_bin (int): Max number of bins that feature values will be bucketed in. This
-            is used for lightgbm's histogram binning algorithm.
-        subsample_for_bin (int): Number of samples for constructing bins (can ignore).
-        min_child_samples (int): Minimum number of data needed in a child (leaf). If
-            less than this number, will not create the child.
-        subsample (float): Subsample ratio of the training instance.
-        subsample_freq (int): Frequence of subsample, <=0 means no enable.
-            How often to subsample the training data.
-        seed (int): Random seed.
-        early_stopping_rounds (int): If `None`, no early stopping is performed. Otherwise,
-            the model will stop training if no improvement is observed in the validation
-        n_jobs (int): Number of parallel threads. If set to -1, the number is set to the
-            number of available cores.
+        n_repeats : int
+            How many times to repeat the training dataset when fitting the score. That is, how many
+            noisy versions of a point to generate for training.
+        n_estimators : int
+            LightGBM: Number of boosting iterations.
+        eval_percent : float
+            LightGBM: Percentage of the training data to use for validation. If `None`, no validation
+            set is used TODO: what happen if early_stopping_rounds is not None but eval_percent is None?
+        early_stopping_rounds : int
+            LightGBM: If `None`, no early stopping is performed. Otherwise, the model will stop training
+            if no improvement is observed in the validation set for `early_stopping_rounds` consecutive
+            iterations.
+        num_leaves : int
+            LightGBM: Maximum tree leaves for base learners.
+        max_depth : int
+            LightGBM: Maximum tree depth for base learners, <=0 means no limit.
+        learning_rate : float
+            LightGBM: Boosting learning rate.
+        max_bin : int
+            LightGBM: Max number of bins that feature values will be bucketed in. This is used for
+            lightgbm's histogram binning algorithm.
+        min_child_samples : int
+            LightGBM: Minimum number of data needed in a child (leaf). If less than this number, will
+            not create the child.
+        subsample : float
+            LightGBM: Subsample ratio of the training instance.
+        subsample_freq : int
+            LightGBM: Frequency of subsample, <=0 means no enable. How often to subsample the training
+            data.
+        n_jobs : int
+            LightGBM: Number of parallel threads. If set to -1, the number is set to the number of available cores.
+        sde_name : str
+            SDE: Name of the SDE to use. See `treeffuser.sde.get_diffusion_sde` for available SDEs.
+        sde_initialize_from_data : bool
+            SDE: Whether to initialize the SDE from the data. If `True`, the SDE hyperparameters are
+            initialized with a heuristic based on the data (see `treeffuser.sde.initialize.py`).
+            Otherwise, sde_hyperparam_min and sde_hyperparam_max are used. (default: False)
+        sde_hyperparam_min : float or "default"
+            SDE: TODO
+        sd_hyperparam_max : float or "default"
+            SDE: TODO
+        seed : int
+            Random seed for generating the training data and fitting the model.
+        verbose : int
+            Verbosity of the score model.
         """
         super().__init__(
             sde_initialize_from_data=sde_initialize_from_data,

--- a/src/treeffuser/treeffuser.py
+++ b/src/treeffuser/treeffuser.py
@@ -19,6 +19,7 @@ class Treeffuser(BaseTabularDiffusion):
         max_depth: int = -1,
         learning_rate: float = 0.1,
         max_bin: int = 255,
+        subsample_for_bin: int = 200000,
         min_child_samples: int = 20,
         subsample: float = 1.0,
         subsample_freq: int = 0,
@@ -53,6 +54,8 @@ class Treeffuser(BaseTabularDiffusion):
         max_bin : int
             LightGBM: Max number of bins that feature values will be bucketed in. This is used for
             lightgbm's histogram binning algorithm.
+        subsample_for_bin : int
+            LightGBM: Number of samples for constructing bins.
         min_child_samples : int
             LightGBM: Minimum number of data needed in a child (leaf). If less than this number, will
             not create the child.

--- a/src/treeffuser/treeffuser.py
+++ b/src/treeffuser/treeffuser.py
@@ -1,6 +1,5 @@
 from typing import Literal
 from typing import Optional
-from typing import Union
 
 from treeffuser._base_tabular_diffusion import BaseTabularDiffusion
 from treeffuser._score_models import LightGBMScoreModel
@@ -26,8 +25,8 @@ class Treeffuser(BaseTabularDiffusion):
         n_jobs: int = -1,
         sde_name: str = "vesde",
         sde_initialize_from_data: bool = False,
-        sde_hyperparam_min: Union[float, Literal["default"]] = None,
-        sde_hyperparam_max: Union[float, Literal["default"]] = None,
+        sde_hyperparam_min: Optional[float | Literal["default"]] = None,
+        sde_hyperparam_max: Optional[float | Literal["default"]] = None,
         seed: Optional[int] = None,
         verbose: int = 0,
         extra_lightgbm_params: Optional[dict] = None,

--- a/src/treeffuser/treeffuser.py
+++ b/src/treeffuser/treeffuser.py
@@ -104,8 +104,6 @@ class Treeffuser(BaseTabularDiffusion):
 
     def get_new_sde(self) -> DiffusionSDE:
         sde_cls = get_diffusion_sde(self.sde_name)
-        if not issubclass(sde_cls, DiffusionSDE):
-            raise ValueError(f"SDE {sde_cls} is not a subclass of DiffusionSDE")
         sde_kwargs = {}
         if self.sde_hyperparam_min is not None:
             sde_kwargs["hyperparam_min"] = self.sde_hyperparam_min

--- a/testbed/src/testbed/metrics/log_likelihood.py
+++ b/testbed/src/testbed/metrics/log_likelihood.py
@@ -3,7 +3,6 @@ from typing import List
 from typing import Union
 
 import numpy as np
-import torch
 from jaxtyping import Float
 from numpy import ndarray
 from sklearn.model_selection import GridSearchCV
@@ -130,9 +129,7 @@ def fit_and_evaluate_int_prob(y_train: Float[ndarray, "n_samples y_dim"], y_test
     total_counts = np.sum(counts) + 1
 
     counts_dict = dict(zip(unique, counts))
-    probs_test = np.array(
-        [(counts_dict.get(y, 0) + epsilon) / total_counts for y in y_test_int]
-    )
+    probs_test = np.array([(counts_dict.get(y, 0) + epsilon) / total_counts for y in y_test_int])
     log_probs_test = np.log(probs_test)
     return np.sum(log_probs_test)
 
@@ -199,6 +196,8 @@ class LogLikelihoodExactMetric(Metric):
             return {
                 "nll_true": np.nan,
             }
+
+        import torch
 
         nll = -y_distribution.log_prob(torch.tensor(y_test)).mean()
 

--- a/testbed/src/testbed/models/base_model.py
+++ b/testbed/src/testbed/models/base_model.py
@@ -5,7 +5,6 @@ from typing import Tuple
 from typing import Type
 
 import numpy as np
-import torch.distributions
 import wandb
 from jaxtyping import Float
 from numpy import ndarray
@@ -49,9 +48,7 @@ class ProbabilisticModel(ABC, BaseEstimator):
         Predict the mean for each input.
         """
 
-    def predict_distribution(
-        self, X: Float[ndarray, "batch x_dim"]
-    ) -> torch.distributions.Distribution:
+    def predict_distribution(self, X: Float[ndarray, "batch x_dim"]):
         """
         Predict the distribution for each input.
         """

--- a/testbed/src/testbed/models/treeffuser.py
+++ b/testbed/src/testbed/models/treeffuser.py
@@ -29,8 +29,9 @@ class Treeffuser(ProbabilisticModel, MultiOutputMixin):
         subsample: float = 1.0,
         subsample_freq: int = 0,
         verbose: bool = 0,
-        sde_initialize_with_data: bool = False,
-        sde_manual_hyperparams: Optional[Dict[str, float]] = None,
+        sde_initialize_from_data: bool = False,
+        sde_hyperparam_min: Optional[float] = None,
+        sde_hyperparam_max: Optional[float] = None,
     ):
         super().__init__(seed)
         self.n_estimators = n_estimators
@@ -41,9 +42,9 @@ class Treeffuser(ProbabilisticModel, MultiOutputMixin):
         self.subsample = subsample
         self.subsample_freq = subsample_freq
         self.verbose = verbose
-        self.sde_manual_hyperparams = sde_manual_hyperparams
-        self.sde_initialize_with_data = sde_initialize_with_data
-
+        self.sde_initialize_from_data = sde_initialize_from_data
+        self.sde_hyperparam_min = sde_hyperparam_min
+        self.sde_hyperparam_max = sde_hyperparam_max
         self.model = None
 
     def fit(
@@ -56,7 +57,9 @@ class Treeffuser(ProbabilisticModel, MultiOutputMixin):
             n_estimators=self.n_estimators,
             n_repeats=self.n_repeats,
             sde_name="vesde",
-            sde_initialize_with_data=self.sde_initialize_with_data,
+            sde_initialize_from_data=self.sde_initialize_from_data,
+            sde_hyperparam_min=self.sde_hyperparam_min,
+            sde_hyperparam_max=self.sde_hyperparam_max,
             learning_rate=self.learning_rate,
             early_stopping_rounds=self.early_stopping_rounds,
             num_leaves=self.num_leaves,
@@ -64,7 +67,6 @@ class Treeffuser(ProbabilisticModel, MultiOutputMixin):
             subsample=self.subsample,
             subsample_freq=self.subsample_freq,
             verbose=self.verbose,
-            sde_manual_hyperparams=self.sde_manual_hyperparams,
         )
 
         self.model.fit(X, y, cat_idx)
@@ -77,7 +79,7 @@ class Treeffuser(ProbabilisticModel, MultiOutputMixin):
     def sample(
         self, X: Float[ndarray, "batch x_dim"], n_samples=10, seed=None
     ) -> Float[ndarray, "n_samples batch y_dim"]:
-        return self.model.sample(X, n_samples, n_parallel=10, n_steps=50, seed=seed)
+        return self.model.sample(X, n_samples, n_parallel=10, n_steps=50, seed=seed, verbose=True)
 
     @staticmethod
     def search_space() -> dict:

--- a/tests/sde/test_initialize.py
+++ b/tests/sde/test_initialize.py
@@ -9,8 +9,8 @@ import pytest
 from jaxtyping import Float
 from numpy import ndarray
 
+from treeffuser.sde import get_diffusion_sde
 from treeffuser.sde import sdeint
-from treeffuser.sde.initialize import initialize_sde
 
 
 def _score_linear_vesde(
@@ -113,7 +113,8 @@ def test_linear_sde(sde_name, score_fn):
     y = alpha * x + np.random.normal(size=(n, y_dim)) * gamma * x
 
     # Define SDE
-    sde = initialize_sde(sde_name, y)
+    sde = get_diffusion_sde(sde_name)()
+    sde.initialize_hyperparams_from_data(y)
     print(sde)
     hyperparams = sde.get_hyperparams()
     score_fn = partial(score_fn, **hyperparams, x=x, alpha=alpha, gamma=gamma)

--- a/tests/sde/test_sdes_and_solvers.py
+++ b/tests/sde/test_sdes_and_solvers.py
@@ -10,9 +10,9 @@ from jaxtyping import Float
 from numpy import ndarray
 
 from treeffuser.sde import sdeint
-from treeffuser.sde.sdes import VESDE
-from treeffuser.sde.sdes import VPSDE
-from treeffuser.sde.sdes import SubVPSDE
+from treeffuser.sde.diffusion_sdes import VESDE
+from treeffuser.sde.diffusion_sdes import VPSDE
+from treeffuser.sde.diffusion_sdes import SubVPSDE
 
 
 def _score_linear_vesde(

--- a/tests/test_score_models.py
+++ b/tests/test_score_models.py
@@ -5,8 +5,7 @@ Contains all of the test for the different score model classes.
 import numpy as np
 from einops import repeat
 
-from treeffuser._score_models import LightGBMScore
-from treeffuser.sde.sdes import VESDE
+from treeffuser._score_models import LightGBMScoreModel
 from treeffuser.sde.diffusion_sdes import VESDE
 
 from .utils import generate_bimodal_linear_regression_data
@@ -41,14 +40,13 @@ def test_linear_regression():
     hyperparam_min = 0.01
     hyperparam_max = y.std()
     sde = VESDE(hyperparam_min=hyperparam_min, hyperparam_max=hyperparam_max)
-    score_model = LightGBMScore(
-        sde=sde,
+    score_model = LightGBMScoreModel(
         verbose=1,
         n_estimators=n_estimators,
         learning_rate=learning_rate,
         n_repeats=n_repeats,
     )
-    score_model.fit(X, y)
+    score_model.fit(X, y, sde)
 
     # Check that the score model is able to fit the data
     random_t = np.random.uniform(1e-5, sde.T // 2, size=n)
@@ -89,26 +87,24 @@ def test_can_be_deterministic():
     seed = 0
 
     # First fit
-    score_model_a = LightGBMScore(
-        sde=sde,
+    score_model_a = LightGBMScoreModel(
         verbose=1,
         n_estimators=n_estimators,
         learning_rate=learning_rate,
         n_repeats=n_repeats,
         seed=seed,
     )
-    score_model_a.fit(X, y)
+    score_model_a.fit(X, y, sde)
 
     # Second fit
-    score_model_b = LightGBMScore(
-        sde=sde,
+    score_model_b = LightGBMScoreModel(
         verbose=1,
         n_estimators=n_estimators,
         learning_rate=learning_rate,
         n_repeats=n_repeats,
         seed=seed,
     )
-    score_model_b.fit(X, y)
+    score_model_b.fit(X, y, sde)
 
     # Check that the two results are the same
     random_t = np.random.uniform(1e-5, sde.T // 2, size=n)
@@ -150,26 +146,24 @@ def test_different_seeds_do_not_give_same_results():
     seed_b = 1
 
     # First fit
-    score_model_a = LightGBMScore(
-        sde=sde,
+    score_model_a = LightGBMScoreModel(
         verbose=1,
         n_estimators=n_estimators,
         learning_rate=learning_rate,
         n_repeats=n_repeats,
         seed=seed_a,
     )
-    score_model_a.fit(X, y)
+    score_model_a.fit(X, y, sde)
 
     # Second fit
-    score_model_b = LightGBMScore(
-        sde=sde,
+    score_model_b = LightGBMScoreModel(
         verbose=1,
         n_estimators=n_estimators,
         learning_rate=learning_rate,
         n_repeats=n_repeats,
         seed=seed_b,
     )
-    score_model_b.fit(X, y)
+    score_model_b.fit(X, y, sde)
 
     # Check that the two results are the same
     random_t = np.random.uniform(1e-5, sde.T // 2, size=n)

--- a/tests/test_score_models.py
+++ b/tests/test_score_models.py
@@ -7,6 +7,7 @@ from einops import repeat
 
 from treeffuser._score_models import LightGBMScore
 from treeffuser.sde.sdes import VESDE
+from treeffuser.sde.diffusion_sdes import VESDE
 
 from .utils import generate_bimodal_linear_regression_data
 from .utils import r2_score


### PR DESCRIPTION
- rename `sdes` into `diffusion_sdes`
- rename `Score` into `ScoreModel`
- add `initialize_hyperparams_from_data` as a method to `DiffusionSDE` so that an existing SDE object can have its parameters initialized after creation.
- make BaseTabularDiffusion work with any `sde` and `score_model` and decouple those two objects (score_model used to have `sde` as a parameter)
- move initialization of preprocessor/score/sde to `fit`, to be compatible with sklearn api such that:
   - cloning and changing TabularDiffusion's parameters and fitting it will use the new parameters.
- re-arrange arguments between `fit` methods to minimize duplicate code (only the public facing Treeffuser class details some parameters, those are then propagated as **kwargs)
- correct bug with `cat_idx` (include changing the parametrization of GBT to [X,y,t])
- remove dependencies of the testbed on torch when not using a torch model